### PR TITLE
Can change the name of downloading file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Prop | Type | Default | Description
 `cols-label-text` | `String` | `'Columns'` | Text for the columns drag area
 `hide-settings-text` | `String` | `'Hide settings'` | Text for the "hide settings" button
 `show-settings-text` | `String` | `'Show settings'` | Text for the "show settings" button
-`filename` | `String` | (Determined by datetime) | Filename for the downloading csv / tsv
+`filename` | `String` | (Determined by datetime) | Filename without extension for the downloading csv / tsv
 
 #### Field format
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Prop | Type | Default | Description
 `cols-label-text` | `String` | `'Columns'` | Text for the columns drag area
 `hide-settings-text` | `String` | `'Hide settings'` | Text for the "hide settings" button
 `show-settings-text` | `String` | `'Show settings'` | Text for the "show settings" button
+`filename` | `String` | (Determined by datetime) | Filename for the downloading csv / tsv
 
 #### Field format
 

--- a/src/Pivot.vue
+++ b/src/Pivot.vue
@@ -51,7 +51,17 @@
 
       <!-- Table -->
       <div class="col table-responsive pivottable">
-        <pivot-table ref="pivottable" :data="data" :row-fields="internal.rowFields" :col-fields="internal.colFields" :reducer="reducer" :no-data-warning-text="noDataWarningText" :is-data-loading="isDataLoading" :style="{ height: tableHeight + 'px'}">
+        <pivot-table
+          ref="pivottable"
+          :data="data"
+          :row-fields="internal.rowFields"
+          :col-fields="internal.colFields"
+          :reducer="reducer"
+          :no-data-warning-text="noDataWarningText"
+          :filename="filename"
+          :is-data-loading="isDataLoading"
+          :style="{ height: tableHeight + 'px'}"
+        >
           <!-- pass down scoped slots -->
           <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ value }">
             <slot :name="slotName" v-bind="{ value }"></slot>
@@ -129,6 +139,10 @@ export default {
     noDataWarningText: {
       type: String,
       default: 'No data to display.'
+    },
+    filename: {
+      type: String,
+      default: ''
     },
     isDataLoading: {
       type: Boolean,

--- a/src/PivotTable.vue
+++ b/src/PivotTable.vue
@@ -84,7 +84,7 @@
 
 <script>
 import naturalSort from 'javascript-natural-sort'
-import { downloadTableWithTSV, downloadTableWithCSV } from './util'
+import { downloadTableWith } from './util'
 
 export default {
   props: {
@@ -111,6 +111,10 @@ export default {
     overNumOfCellsWarningText: {
       type: String,
       default: 'Too many cells. Please reduce the num of rows / cols.'
+    },
+    filename: {
+      type: String,
+      default: ''
     },
     numOfCellsLimitation: {
       type: Number,
@@ -311,10 +315,10 @@ export default {
     saveTableWithText (format) {
       switch (format) {
       case 'csv':
-        downloadTableWithCSV(this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values)
+        downloadTableWith('csv', this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values, this.filename)
         break
       case 'tsv':
-        downloadTableWithTSV(this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values)
+        downloadTableWith('tsv', this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values, this.filename)
         break
       default:
         break

--- a/src/PivotTable.vue
+++ b/src/PivotTable.vue
@@ -313,16 +313,7 @@ export default {
       })
     },
     saveTableWithText (format) {
-      switch (format) {
-      case 'csv':
-        downloadTableWith('csv', this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values, this.filename)
-        break
-      case 'tsv':
-        downloadTableWith('tsv', this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values, this.filename)
-        break
-      default:
-        break
-      }
+      downloadTableWith(format, this.cols, this.colFields, this.rows, this.rowFields, this.rowHeaderSize, this.values, this.filename)
     }
   },
   watch: {

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,11 @@
-export function downloadTableWithTSV (cols, colFields, rows, rowFields, rowHeaderSize, values) {
-  let filename = getFilenameByDate(new Date()) + '.tsv'
-  formatAndDownloadWithText(cols, colFields, rows, rowFields, rowHeaderSize, values, '\t', filename)
-}
-
-export function downloadTableWithCSV (cols, colFields, rows, rowFields, rowHeaderSize, values) {
-  let filename = getFilenameByDate(new Date()) + '.csv'
-  formatAndDownloadWithText(cols, colFields, rows, rowFields, rowHeaderSize, values, ',', filename)
+export function downloadTableWith (format, cols, colFields, rows, rowFields, rowHeaderSize, values, filename) {
+  if (format !== 'tsv' && format !== 'csv') {
+    console.error('Invalid format on downloadTable')
+    return
+  }
+  const _filename = (filename || getFilenameByDate(new Date())) + '.' + format
+  const delimiter = format === 'tsv' ? '\t' : ','
+  formatAndDownloadWithText(cols, colFields, rows, rowFields, rowHeaderSize, values, delimiter, _filename)
 }
 
 function toDoubleDigits (num) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 export function downloadTableWith (format, cols, colFields, rows, rowFields, rowHeaderSize, values, filename) {
   if (format !== 'tsv' && format !== 'csv') {
-    throw Error('Invalid format on downloadTable')
+    throw Error('Invalid format on downloading, only "tsv" or "csv" can be used.')
   }
   const _filename = (filename || getFilenameByDate(new Date())) + '.' + format
   const delimiter = format === 'tsv' ? '\t' : ','

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,6 @@
 export function downloadTableWith (format, cols, colFields, rows, rowFields, rowHeaderSize, values, filename) {
   if (format !== 'tsv' && format !== 'csv') {
-    console.error('Invalid format on downloadTable')
-    return
+    throw Error('Invalid format on downloadTable')
   }
   const _filename = (filename || getFilenameByDate(new Date())) + '.' + format
   const delimiter = format === 'tsv' ? '\t' : ','


### PR DESCRIPTION
Fix https://github.com/line/vue-pivot-table-plus/issues/10 .

Can change filename of downloading csv / tsv.

`another_filename.csv` or `another_filename.tsv` will be downloaded in below example.
```
<pivot
  ...
  filename="another_filename"
>
```