### PR TITLE
Add copy-to-clipboard button to menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pivot-table-plus",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3167,6 +3167,16 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "clipboardy": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
@@ -4437,6 +4447,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6295,6 +6310,14 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -11222,6 +11245,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -12454,6 +12482,11 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-pivot-table-plus",
   "description": "A customized vue component for pivot table",
   "private": false,
-  "version": "0.6.2",
+  "version": "0.7.0",
   "author": "LINE Corporation",
   "license": "Apache-2.0",
   "repository": {
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "bootstrap-vue": "^2.18.1",
+    "clipboard": "^2.0.6",
     "core-js": "^2.6.11",
     "javascript-natural-sort": "^0.7.1",
     "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-pivot-table-plus",
   "description": "A customized vue component for pivot table",
   "private": false,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "LINE Corporation",
   "license": "Apache-2.0",
   "repository": {

--- a/src/Pivot.vue
+++ b/src/Pivot.vue
@@ -70,16 +70,18 @@
             <slot name="loading"></slot>
           </template>
         </pivot-table>
-        <div ref="pivot-copied-alert" class="alert alert-secondary pivot-alert hide" @click="hideCopiedAlert">
-          Copied to clipboard
-        </div>
+        <transition name="copied-alert">
+          <div v-if="showCopiedAlert" class="alert alert-secondary pivot-copied-alert">
+            Copied to clipboard
+          </div>
+        </transition>
       </div>
 
       <div v-if="showSettings" class="table-option-button circle-background bg-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-b-tooltip:hover title="Show menu"></div>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-        <a ref="pivot-copy-button" class="dropdown-item" href="#">Copy table to clipboard</a>
-        <a class="dropdown-item" href="#!" @click="_clickedSaveButton('csv')">Save table in CSV</a>
-        <a class="dropdown-item" href="#!" @click="_clickedSaveButton('tsv')">Save table in TSV</a>
+        <button ref="pivot-copy-button" class="dropdown-item" >Copy table to clipboard</button>
+        <button class="dropdown-item" @click="_clickedSaveButton('csv')">Save table in CSV</button>
+        <button class="dropdown-item" @click="_clickedSaveButton('tsv')">Save table in TSV</button>
       </div>
     </div>
   </div>
@@ -166,7 +168,8 @@ export default {
         colFields: this.fields.colFields,
         fieldsOrder: this.fields.fieldsOrder
       },
-      dragging: false
+      dragging: false,
+      showCopiedAlert: false
     }
   },
   created () {
@@ -255,20 +258,9 @@ export default {
       }
       this._sortFields(this.internal.fieldsOrder)
     },
-    onPivotTableCopied (e) {
-      this.showCopiedAlert()
-      setTimeout(this.startHideCopiedAlert, 500)
-    },
-    showCopiedAlert () {
-      this.$refs['pivot-copied-alert'].classList.remove('hide')
-    },
-    startHideCopiedAlert () {
-      this.$refs['pivot-copied-alert'].classList.add('hiding')
-      setTimeout(this.hideCopiedAlert, 1000)
-    },
-    hideCopiedAlert () {
-      this.$refs['pivot-copied-alert'].classList.remove('hiding')
-      this.$refs['pivot-copied-alert'].classList.add('hide')
+    onPivotTableCopied () {
+      this.showCopiedAlert = true
+      setTimeout(() => { this.showCopiedAlert = false }, 700)
     }
   }
 }
@@ -413,19 +405,17 @@ $hamburger-svg: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/
   left: $base-space*3 + 10rem - $border-space*3;
 }
 
-.pivot-alert {
+.pivot-copied-alert {
   position: absolute;
   bottom: 1rem;
   right: 1rem;
-  opacity: 0.8;
-  visibility: vislble;
-  transition: opacity 1s ease-in-out;
-  &.hiding {
-    opacity: 0;
-    visibility: visible;
-  }
-  &.hide {
-    visibility: hidden;
-  }
+}
+
+.copied-alert-enter-active {
+  opacity: 0.6;
+}
+.copied-alert-leave-active {
+  opacity: 0;
+  transition: all 0.7s ease;
 }
 </style>


### PR DESCRIPTION
Added a button to copy pivot table to clipboard into menu.

<image width=640 src="https://user-images.githubusercontent.com/11585311/99221007-1ec31580-2823-11eb-9543-1262564fe1e0.png" />

Can paste to excel / numbers / google-spreadsheet etc.

- Numbers
<image width=640 src="https://user-images.githubusercontent.com/11585311/99220738-8a58b300-2822-11eb-9621-86cc1cd3460d.png" />

For Excel, `rowspan` and `colspan` are ignored.

- Excel
<image width=640 src="https://user-images.githubusercontent.com/11585311/99220812-b6743400-2822-11eb-974b-0447ca4dbccf.png" />
